### PR TITLE
Make the values module public.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ mod parser;
 mod runtime;
 mod serde;
 mod sort;
-mod value;
+pub mod value;
 
 pub trait IntoValue: Sized {
     fn into_value(&self, _: &agent::Agent) -> value::Value;


### PR DESCRIPTION
This allows the user to access ObjectKeys, so that they can retrieve a specific function from the vm.